### PR TITLE
middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'admin' => \App\Http\Middleware\CheckAdmin::class,
     ];
 }

--- a/app/Http/Middleware/CheckAdmin.php
+++ b/app/Http/Middleware/CheckAdmin.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckAdmin
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = auth()->user();
+
+        if ($user && $user->is_admin) { 
+            return $next($request);
+        }
+
+        abort(401);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ Route::get('/', function () {
 });
 
 Route::prefix('/users')
+    ->middleware('admin')
     ->controller(UserController::class)
     ->group(function () {
         Route::get('/', 'index')->name('users.index');


### PR DESCRIPTION
### 1. Middleware dùng để làm gì?

- Middleware được sử dụng để xử lý các yêu cầu HTTP trước khi chúng được chuyển đến các tác vụ xử lý chính. Nó cho phép bạn thực hiện các kiểm tra, xác thực, ghi log, xử lý lỗi và các tác vụ khác trước khi yêu cầu đến được xử lý hoặc trả về phản hồi. 

### 2. Phân biệt Global Middleware, Group Middleware và Route Middleware

1. Global Middleware:

- Global Middleware là các Middleware được áp dụng cho tất cả các yêu cầu HTTP trong ứng dụng.
- Để đăng ký Global Middleware, bạn cần chỉ định chúng trong thuộc tính `$middleware` trong tệp `app/Http/Kernel.php`.
```php
protected $middleware = [
        \App\Http\Middleware\TrustProxies::class,
        \Illuminate\Http\Middleware\HandleCors::class,
        \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
        \App\Http\Middleware\TrimStrings::class,
        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
    ];
```
- Global Middleware được thực hiện trước khi yêu cầu đi qua bất kỳ tuyến đường cụ thể nào trong ứng dụng.

2. Group Middleware:

- Group Middleware là các Middleware được nhóm lại và áp dụng cho một nhóm cụ thể của các routes.
- Bằng cách sử dụng Group Middleware, bạn có thể xác định các Middleware sẽ được áp dụng cho một nhóm routes cụ thể.
- Để đăng ký Group Middleware, bạn cần chỉ định chúng trong phương thức `Route::middleware()` trước khi định nghĩa nhóm routes.
- Group Middleware chỉ được thực hiện khi yêu cầu đi qua các routes thuộc nhóm đó.
- Ví dụ: Middleware admin để đảm bảo rằng người dùng phải là admin khi truy cập vào nhóm các routes CRUD users.
```php
Route::prefix('/users')
    ->middleware('admin')
    ->controller(UserController::class)
    ->group(function () {
        Route::get('/', 'index')->name('users.index');
        Route::get('/create', 'create')->name('users.create');
        // ...
    });
```
3. Route Middleware:

- Route Middleware là các Middleware được áp dụng cho một route cụ thể.
- Bạn có thể xác định Route Middleware cho một route trong tệp `route` hoặc thông qua định nghĩa `route` trong một nhóm `routes`.
- Route Middleware chỉ được thực hiện khi yêu cầu đi qua route cụ thể đó.
- Ví dụ: Middleware admin để đảm bảo rằng người dùng phải là admin khi truy cập vào trang admin dasboard.
```php
Route::get('/admin/dashboard', [HomeController::class, 'dashboard'])
    ->middleware('admin');
```